### PR TITLE
修复登录 tab 加载 bug 及 fix #190

### DIFF
--- a/src/main/resources/static/febs/lay/modules/febs.js
+++ b/src/main/resources/static/febs/lay/modules/febs.js
@@ -42,6 +42,9 @@ layui.extend({
         layui.each(layui.conf.style, function (index, url) {
             layui.link(url + '?v=' + conf.v)
         });
+        if (!self.route.href || self.route.href === '/') {
+            self.route = self.defaultView
+        }
         if (self.route.href !== self.defaultView.href) {
             self.initView(self.defaultView, {unshift: true, focus: false})
         }

--- a/src/main/resources/static/febs/lay/modules/view.js
+++ b/src/main/resources/static/febs/lay/modules/view.js
@@ -328,6 +328,10 @@ layui
                         })
                 },
                 del: function (url, backgroundDel) {
+                    if (url === layui.febs.defaultView.href) {
+                        layui.febs.alert.warn(layui.febs.defaultView.title + '无法删除！')
+                        return;
+                    }
                     var tab = this;
                     if (tab.data.length <= 1 && backgroundDel === undefined) return;
                     layui.each(tab.data, function (i, data) {
@@ -367,7 +371,6 @@ layui
                     if (!options) options = {}
                     var unshift = options.unshift | false
                     var focus = options.focus !== false
-                    console.log(options, unshift, focus)
                     if (typeof route == 'string') {
                         route = layui.router('#' + route);
                         route.fileurl = '/' + route.path.join('/')
@@ -432,11 +435,14 @@ layui
 
                             layui.febs.render(tab.tabMenuTplId);
 
-                            if (focus) {
-                                var currentMenu = $(tab.menu + ' ' + lay);
-                                currentMenu.addClass(activeCls);
-                                changeView(lay);
+                            if (!focus) {
+                                if (tab.data.length > 1) {
+                                    lay = '[lay-url="' + tab.data[1].fileurl + '"]';
+                                }
                             }
+                            var currentMenu = $(tab.menu + ' ' + lay);
+                            currentMenu.addClass(activeCls);
+                            changeView(lay);
 
                             if ($.isFunction(callback)) callback(params)
                         })


### PR DESCRIPTION
当前端左侧菜单未加载完成时 tab 还是会根据 lay-title 加载，可能会与配置的菜单名不一致。如果要彻底解决需要返回给前端菜单配置或后端渲染 lay-title