### PR TITLE
fix(sec): upgrade org.apache.shiro:shiro-spring to 1.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <commons-io.version>2.8.0</commons-io.version>
         <shiro.redis.version>3.3.1</shiro.redis.version>
         <easy-captcha.version>1.6.2</easy-captcha.version>
-        <shiro.spring.version>1.7.0</shiro.spring.version>
+        <shiro.spring.version>1.9.1</shiro.spring.version>
         <mybatis.plus.version>3.4.0</mybatis.plus.version>
         <shiro.ehcache.version>1.7.1</shiro.ehcache.version>
         <google.guava.version>30.1-jre</google.guava.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.shiro:shiro-spring 1.7.0
- [CVE-2022-32532](https://www.oscs1024.com/hd/CVE-2022-32532)


### What did I do？
Upgrade org.apache.shiro:shiro-spring from 1.7.0 to 1.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS